### PR TITLE
ISN-6794 - Fix syntax error since PHP 8 doesn't allow { to refer to array indexes

### DIFF
--- a/includes/PHPExcel-1.8.1/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/includes/PHPExcel-1.8.1/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -95,7 +95,7 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
 		// Open file
 		$this->_openFile($pFilename);
 		$fileHandle = $this->_fileHandle;
-		
+
 		// Read sample data (first 2 KB will do)
 		$data = fread($fileHandle, 2048);
 		fclose($fileHandle);
@@ -702,12 +702,12 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
 												//	Empty R reference is the current row
 												if ($rowReference == '') $rowReference = $rowID;
 												//	Bracketed R references are relative to the current row
-												if ($rowReference{0} == '[') $rowReference = $rowID + trim($rowReference,'[]');
+												if ($rowReference[0] == '[') $rowReference = $rowID + trim($rowReference,'[]');
 												$columnReference = $cellReference[4][0];
 												//	Empty C reference is the current column
 												if ($columnReference == '') $columnReference = $columnNumber;
 												//	Bracketed C references are relative to the current column
-												if ($columnReference{0} == '[') $columnReference = $columnNumber + trim($columnReference,'[]');
+												if ($columnReference[0] == '[') $columnReference = $columnNumber + trim($columnReference,'[]');
 												$A1CellReference = PHPExcel_Cell::stringFromColumnIndex($columnReference-1).$rowReference;
 													$value = substr_replace($value,$A1CellReference,$cellReference[0][1],strlen($cellReference[0][0]));
 											}


### PR DESCRIPTION
Fixes this error in Datadog:

E_COMPILE_ERROR: Array and string offset access syntax with curly braces is no longer supported
#0 /var/www/isn/vendor/inspectionsupport/pegasusphp.org/includes/PHPExcel-1.8.1/Classes/PHPExcel/Autoloader.php(36): PHPExcel_Autoloader::Load()
#1 /var/www/isn/vendor/inspectionsupport/pegasusphp.org/includes/PHPExcel-1.8.1/Classes/PHPExcel.php(32): require()
#2 /var/www/isn/www/src/HmInspectionLogController.php(3): require_once()
#3 /var/www/isn/vendor/composer/ClassLoader.php(576): include()
#4 /var/www/isn/vendor/composer/ClassLoader.php(427): Composer\Autoload\{closure}()
#5 [internal function]: Composer\Autoload\ClassLoader->loadClass()
#6 /var/www/isn/vendor/inspectionsupport/pegasusphp.org/objects/SimpleRouter.php(286): class_exists()
#7 /var/www/isn/vendor/inspectionsupport/pegasusphp.org/objects/SimpleRouter.php(313): SimpleRouter::dispatch()
#8 /var/www/isn/www/index.php(645): SimpleRouter::process()
#9 {main}

### Ticket
- https://porchdotcom.atlassian.net/browse/ISN-6794